### PR TITLE
[UWP] Add HostBackdrop support

### DIFF
--- a/MaterialFrame/MaterialFrame.UWP/UWPMaterialFrameRenderer.cs
+++ b/MaterialFrame/MaterialFrame.UWP/UWPMaterialFrameRenderer.cs
@@ -30,10 +30,13 @@ namespace Sharpnado.MaterialFrame.UWP
     public class UWPMaterialFrameRenderer : ViewRenderer<MaterialFrame, Grid>
     {
         private static readonly Color DarkBlurOverlayColor = Color.FromHex("#80000000");
+        private static readonly Color DarkFallBackColor = Color.FromHex("#333333");
 
         private static readonly Color LightBlurOverlayColor = Color.FromHex("#40FFFFFF");
+        private static readonly Color LightFallBackColor = Color.FromHex("#F3F3F3");
 
         private static readonly Color ExtraLightBlurOverlayColor = Color.FromHex("#B0FFFFFF");
+        private static readonly Color ExtraLightFallBackColor = Color.FromHex("#FBFBFB");
 
         private Rectangle _acrylicRectangle;
         private Rectangle _shadowHost;
@@ -369,12 +372,15 @@ namespace Sharpnado.MaterialFrame.UWP
             {
                 case MaterialFrame.BlurStyle.ExtraLight:
                     acrylicBrush.TintColor = ExtraLightBlurOverlayColor.ToWindowsColor();
+                    acrylicBrush.FallbackColor = ExtraLightFallBackColor.ToWindowsColor();
                     break;
                 case MaterialFrame.BlurStyle.Dark:
                     acrylicBrush.TintColor = DarkBlurOverlayColor.ToWindowsColor();
+                    acrylicBrush.FallbackColor = DarkFallBackColor.ToWindowsColor();
                     break;
                 default:
                     acrylicBrush.TintColor = LightBlurOverlayColor.ToWindowsColor();
+                    acrylicBrush.FallbackColor = LightFallBackColor.ToWindowsColor();
                     break;
             }
 

--- a/MaterialFrame/MaterialFrame.UWP/UWPMaterialFrameRenderer.cs
+++ b/MaterialFrame/MaterialFrame.UWP/UWPMaterialFrameRenderer.cs
@@ -363,7 +363,7 @@ namespace Sharpnado.MaterialFrame.UWP
                 return;
             }
 
-            var acrylicBrush = new AcrylicBrush { BackgroundSource = AcrylicBackgroundSource.HostBackdrop };
+            var acrylicBrush = new AcrylicBrush { BackgroundSource = AcrylicBackgroundSource.Backdrop };
 
             switch (Element.MaterialBlurStyle)
             {
@@ -373,7 +373,6 @@ namespace Sharpnado.MaterialFrame.UWP
                 case MaterialFrame.BlurStyle.Dark:
                     acrylicBrush.TintColor = DarkBlurOverlayColor.ToWindowsColor();
                     break;
-
                 default:
                     acrylicBrush.TintColor = LightBlurOverlayColor.ToWindowsColor();
                     break;
@@ -389,13 +388,24 @@ namespace Sharpnado.MaterialFrame.UWP
                 return;
             }
 
-            if (Element.UwpBlurOverlayColor != Color.Default)
+            if (Element.UwpBlurOverlayColor != Color.Default && Element.UwpHostBackdropBlur != true)
             {
                 var acrylicBrush = new AcrylicBrush
                     {
-                        BackgroundSource = AcrylicBackgroundSource.HostBackdrop,
+                        BackgroundSource = AcrylicBackgroundSource.Backdrop,
                         TintColor = Element.UwpBlurOverlayColor.ToWindowsColor(),
                     };
+
+                _grid.Background = acrylicBrush;
+                return;
+            }
+            else if (Element.UwpBlurOverlayColor != Color.Default && Element.UwpHostBackdropBlur == true)
+            {
+                var acrylicBrush = new AcrylicBrush
+                {
+                    BackgroundSource = AcrylicBackgroundSource.HostBackdrop,
+                    TintColor = Element.UwpBlurOverlayColor.ToWindowsColor(),
+                };
 
                 _grid.Background = acrylicBrush;
                 return;

--- a/MaterialFrame/MaterialFrame.UWP/UWPMaterialFrameRenderer.cs
+++ b/MaterialFrame/MaterialFrame.UWP/UWPMaterialFrameRenderer.cs
@@ -363,7 +363,7 @@ namespace Sharpnado.MaterialFrame.UWP
                 return;
             }
 
-            var acrylicBrush = new AcrylicBrush { BackgroundSource = AcrylicBackgroundSource.Backdrop };
+            var acrylicBrush = new AcrylicBrush { BackgroundSource = Element.UwpHostBackdropBlur ? AcrylicBackgroundSource.HostBackdrop : AcrylicBackgroundSource.Backdrop };
 
             switch (Element.MaterialBlurStyle)
             {
@@ -388,22 +388,11 @@ namespace Sharpnado.MaterialFrame.UWP
                 return;
             }
 
-            if (Element.UwpBlurOverlayColor != Color.Default && Element.UwpHostBackdropBlur != true)
-            {
-                var acrylicBrush = new AcrylicBrush
-                    {
-                        BackgroundSource = AcrylicBackgroundSource.Backdrop,
-                        TintColor = Element.UwpBlurOverlayColor.ToWindowsColor(),
-                    };
-
-                _grid.Background = acrylicBrush;
-                return;
-            }
-            else if (Element.UwpBlurOverlayColor != Color.Default && Element.UwpHostBackdropBlur == true)
+            if (Element.UwpBlurOverlayColor != Color.Default)
             {
                 var acrylicBrush = new AcrylicBrush
                 {
-                    BackgroundSource = AcrylicBackgroundSource.HostBackdrop,
+                    BackgroundSource = Element.UwpHostBackdropBlur ? AcrylicBackgroundSource.HostBackdrop : AcrylicBackgroundSource.Backdrop,
                     TintColor = Element.UwpBlurOverlayColor.ToWindowsColor(),
                 };
 

--- a/MaterialFrame/MaterialFrame.UWP/UWPMaterialFrameRenderer.cs
+++ b/MaterialFrame/MaterialFrame.UWP/UWPMaterialFrameRenderer.cs
@@ -1,13 +1,13 @@
-﻿using System.ComponentModel;
-using System.Numerics;
+﻿using System.Numerics;
+using System.ComponentModel;
 
-using Windows.UI.Composition;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Automation.Peers;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Hosting;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Shapes;
+using Windows.UI.Composition;
+using Windows.UI.Xaml.Hosting;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Automation.Peers;
 
 using Sharpnado.MaterialFrame;
 using Sharpnado.MaterialFrame.UWP;
@@ -15,9 +15,9 @@ using Sharpnado.MaterialFrame.UWP;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform.UWP;
 
-using AcrylicBackgroundSource = Microsoft.UI.Xaml.Media.AcrylicBackgroundSource;
-using AcrylicBrush = Microsoft.UI.Xaml.Media.AcrylicBrush;
 using Color = Xamarin.Forms.Color;
+using AcrylicBrush = Microsoft.UI.Xaml.Media.AcrylicBrush;
+using AcrylicBackgroundSource = Microsoft.UI.Xaml.Media.AcrylicBackgroundSource;
 
 [assembly: ExportRenderer(typeof(MaterialFrame), typeof(UWPMaterialFrameRenderer))]
 
@@ -363,7 +363,7 @@ namespace Sharpnado.MaterialFrame.UWP
                 return;
             }
 
-            var acrylicBrush = new AcrylicBrush { BackgroundSource = AcrylicBackgroundSource.Backdrop };
+            var acrylicBrush = new AcrylicBrush { BackgroundSource = AcrylicBackgroundSource.HostBackdrop };
 
             switch (Element.MaterialBlurStyle)
             {
@@ -393,7 +393,7 @@ namespace Sharpnado.MaterialFrame.UWP
             {
                 var acrylicBrush = new AcrylicBrush
                     {
-                        BackgroundSource = AcrylicBackgroundSource.Backdrop,
+                        BackgroundSource = AcrylicBackgroundSource.HostBackdrop,
                         TintColor = Element.UwpBlurOverlayColor.ToWindowsColor(),
                     };
 

--- a/MaterialFrame/MaterialFrame/MaterialFrame.UWP.cs
+++ b/MaterialFrame/MaterialFrame/MaterialFrame.UWP.cs
@@ -10,6 +10,12 @@ namespace Sharpnado.MaterialFrame
             typeof(MaterialFrame),
             defaultValueCreator: _ => Color.Default);
 
+        public static readonly BindableProperty UwpHostBackdropBlurProperty = BindableProperty.Create(
+            nameof(UwpHostBackdropBlur),
+            typeof(bool),
+            typeof(MaterialFrame),
+            defaultValueCreator: _ => false);
+
         /// <summary>
         /// UWP only.
         /// Changes the overlay color over the blur (should be a transparent color, obviously).
@@ -19,6 +25,17 @@ namespace Sharpnado.MaterialFrame
         {
             get => (Color)GetValue(UwpBlurOverlayColorProperty);
             set => SetValue(UwpBlurOverlayColorProperty, value);
+        }
+
+        /// <summary>
+        /// UWP only.
+        /// HostBackdropBlur reveals the desktop wallpaper and other windows that are behind the currently active app.
+        /// If not set, the default in app BackdropBlur take over.
+        /// </summary>
+        public bool UwpHostBackdropBlur
+        {
+            get => (bool)GetValue(UwpHostBackdropBlurProperty);
+            set => SetValue(UwpHostBackdropBlurProperty, value);
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###

It adds UWPHostBackdrop property in MaterialFrame.

### Issues Resolved ### 

- Closes #20

### API Changes ###

 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

MaterialFrame now reveals the desktop wallpaper and other windows that are behind the currently active app.

### Screenshots ### 

![image](https://user-images.githubusercontent.com/42671084/121916756-4ad74400-cce9-11eb-9bed-3afdcbe7a294.png)

### Testing Procedure ###

Add a main tag of MaterialFrame.
Change the MaterialTheme property to AcrylicBlur.
Set UwpHostBackdropBlur to true.