### PR TITLE
updates for macOS PR #18

### DIFF
--- a/MaterialFrame/MaterialFrame.macOS/macOSMaterialFrameRenderer.cs
+++ b/MaterialFrame/MaterialFrame.macOS/macOSMaterialFrameRenderer.cs
@@ -346,7 +346,7 @@ namespace Sharpnado.MaterialFrame.macOS
             {
                 InternalLogger.Debug(Tag, () => "UpdateLayerBounds()");
 
-                _intermediateLayer.Frame = new CGRect(0, 2, Element.Width, Element.Height - 2);
+                _intermediateLayer.Frame = new CGRect(0, 0, Element.Width, Element.Height - 2);
                 _intermediateLayer.RemoveAllAnimations();
             }
         }

--- a/MaterialFrame/MaterialFrame.macOS/macOSMaterialFrameRenderer.cs
+++ b/MaterialFrame/MaterialFrame.macOS/macOSMaterialFrameRenderer.cs
@@ -197,7 +197,7 @@ namespace Sharpnado.MaterialFrame.macOS
 
             Layer.ShadowColor = NSColor.Black.CGColor;
             Layer.ShadowRadius = Math.Abs(adaptedElevation);
-            Layer.ShadowOffset = new CGSize(0, adaptedElevation);
+            Layer.ShadowOffset = new CGSize(0, -adaptedElevation);
             Layer.ShadowOpacity = opacity;
 
             Layer.MasksToBounds = false;

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ public App()
 
 `iOSMaterialFrameRenderer.Init();`
 
+* On `macOS` add this line after `Xamarin.Forms.Forms.Init()` and before `LoadApplication(new App())`.
+
+`macOSMaterialFrameRenderer.Init();`
+
 * On `UWP`, you must register the renderers assembly like this, before `Xamarin.Forms.Forms.Init()`:
 
 `var rendererAssemblies = new[] { typeof(UWPMaterialFrameRenderer).GetTypeInfo().Assembly }; `

--- a/Sharpnado.MaterialFrame.nuspec
+++ b/Sharpnado.MaterialFrame.nuspec
@@ -51,6 +51,10 @@ Mandatory initialization on UWP:
           <dependency id="Xamarin.Forms" version="3.6.0.220655" exclude="Build,Analyzers"/>
         </group>
 
+        <group targetFramework="Xamarin.Mac">
+          <dependency id="Xamarin.Forms" version="3.6.0.220655" exclude="Build,Analyzers" />
+        </group>
+
         <group targetFramework="MonoAndroid10">
           <dependency id="Xamarin.Forms" version="3.6.0.220655" exclude="Build,Analyzers"/>
         </group>
@@ -96,6 +100,12 @@ Mandatory initialization on UWP:
         <file src="MaterialFrame\MaterialFrame.iOS\bin\Release\Sharpnado.MaterialFrame.iOS.pdb" target="lib\Xamarin.iOS10\Sharpnado.MaterialFrame.iOS.pdb" />
         <file src="MaterialFrame\MaterialFrame.iOS\bin\Release\Sharpnado.MaterialFrame.dll" target="lib\Xamarin.iOS10\Sharpnado.MaterialFrame.dll" />
         <file src="MaterialFrame\MaterialFrame.iOS\bin\Release\Sharpnado.MaterialFrame.pdb" target="lib\Xamarin.iOS10\Sharpnado.MaterialFrame.pdb" />
+
+        <!--Xamarin.Mac-->
+        <file src="MaterialFrame\MaterialFrame.macOS\bin\Release\Sharpnado.MaterialFrame.macOS.dll" target="lib\Xamarin.Mac\Sharpnado.MaterialFrame.macOS.dll" />
+        <file src="MaterialFrame\MaterialFrame.macOS\bin\Release\Sharpnado.MaterialFrame.macOS.pdb" target="lib\Xamarin.Mac\Sharpnado.MaterialFrame.macOS.pdb" />
+        <file src="MaterialFrame\MaterialFrame.macOS\bin\Release\Sharpnado.MaterialFrame.dll" target="lib\Xamarin.Mac\Sharpnado.MaterialFrame.dll" />
+        <file src="MaterialFrame\MaterialFrame.macOS\bin\Release\Sharpnado.MaterialFrame.pdb" target="lib\Xamarin.Mac\Sharpnado.MaterialFrame.pdb" />
 
         <!--Xamarin.UWP-->
         <file src="MaterialFrame\MaterialFrame.UWP\bin\Release\Sharpnado.MaterialFrame.UWP.dll" target="lib\uap10.0.16299\Sharpnado.MaterialFrame.UWP.dll" />

--- a/make-package.ps1
+++ b/make-package.ps1
@@ -3,6 +3,7 @@ $formsVersion = "3.6.0.220655"
 $netstandardProject = ".\MaterialFrame\MaterialFrame\MaterialFrame.csproj"
 $droidProject = ".\MaterialFrame\MaterialFrame.Android\MaterialFrame.Android.csproj"
 $iosProject = ".\MaterialFrame\MaterialFrame.iOS\MaterialFrame.iOS.csproj"
+$macOSProject = ".\MaterialFrame\MaterialFrame.macOS\MaterialFrame.macOS.csproj"
 $uwpProject = ".\MaterialFrame\MaterialFrame.UWP\MaterialFrame.UWP.csproj"
 
 $droidBin = ".\MaterialFrame\MaterialFrame.Android\bin\Release"
@@ -16,6 +17,7 @@ $replaceString = "`$1 $formsVersion `$3"
 (Get-Content $netstandardProject -Raw) -replace $findXFVersion, "$replaceString" | Out-File $netstandardProject
 (Get-Content $droidProject -Raw) -replace $findXFVersion, "$replaceString" | Out-File $droidProject
 (Get-Content $iosProject -Raw) -replace $findXFVersion, "$replaceString" | Out-File $iosProject
+(Get-Content $macOSProject -Raw) -replace $findXFVersion, "$replaceString" | Out-File $macOSProject
 (Get-Content $uwpProject -Raw) -replace $findXFVersion, "$replaceString" | Out-File $uwpProject
 
 rm *.txt


### PR DESCRIPTION
here are my updates adressing the comment in #18 (https://github.com/roubachof/Sharpnado.MaterialFrame/pull/18#issuecomment-866705319)

i have updated the `nuspec` file and `make-package` script to produce packages for macOS. Also the acrylic effect works as expected now on macOS. Here is a comparison of acrylic on iOS and macOS
<img width="897" alt="Screenshot at Jun 30 08-44-16" src="https://user-images.githubusercontent.com/3210391/123914137-5e3c0d80-d97f-11eb-9dbb-7a7bebc55926.png">


README.md is also updated with info about initialization on macOS