### PR TITLE
[macOS] Add BehindWindow support

### DIFF
--- a/MaterialFrame/MaterialFrame.macOS/macOSMaterialFrameRenderer.cs
+++ b/MaterialFrame/MaterialFrame.macOS/macOSMaterialFrameRenderer.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using AppKit;
+
+using System;
 using System.ComponentModel;
 
 using CoreAnimation;
@@ -9,8 +11,6 @@ using Foundation;
 
 using Sharpnado.MaterialFrame;
 using Sharpnado.MaterialFrame.macOS;
-
-using AppKit;
 
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.MacOS;
@@ -308,7 +308,7 @@ namespace Sharpnado.MaterialFrame.macOS
 
             if (_blurView != null)
             {
-                _blurView.BlendingMode = NSVisualEffectBlendingMode.WithinWindow;
+                _blurView.BlendingMode = Element.macOSBehindWindowBlur ? NSVisualEffectBlendingMode.BehindWindow : NSVisualEffectBlendingMode.WithinWindow;
                 _blurView.Material = ConvertBlurStyle();
             }
         }

--- a/MaterialFrame/MaterialFrame/MaterialFrame.macOS.cs
+++ b/MaterialFrame/MaterialFrame/MaterialFrame.macOS.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms;
+
+namespace Sharpnado.MaterialFrame
+{
+    public partial class MaterialFrame
+    {
+        public static readonly BindableProperty macOSBehindWindowBlurProperty = BindableProperty.Create(
+            nameof(macOSBehindWindowBlur),
+            typeof(bool),
+            typeof(MaterialFrame),
+            defaultValueCreator: _ => false);
+
+        /// <summary>
+        /// macOS only.
+        /// BehindWindow reveals the desktop wallpaper and other windows that are behind the currently active app.
+        /// If not set, the default in app WithinWindow take over.
+        /// </summary>
+        public bool macOSBehindWindowBlur
+        {
+            get => (bool)GetValue(macOSBehindWindowBlurProperty);
+            set => SetValue(macOSBehindWindowBlurProperty, value);
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###

It adds macOSBehindWindowBlur property in MaterialFrame.

### Issues Resolved ### 

- Closes #20

### API Changes ###

 None

### Platforms Affected ### 

- macOS

### Behavioral/Visual Changes ###

MaterialFrame now reveals the desktop wallpaper and other windows that are behind the currently active app. 

### Screenshots ### 

![IMG_2057](https://user-images.githubusercontent.com/42671084/136807233-7c470875-716c-471b-b60a-d8d02da109b9.JPG)
![IMG_2056](https://user-images.githubusercontent.com/42671084/136807203-f170e113-bddd-4c94-9ab3-dedefd9d18cd.JPG)

### Testing Procedure ###

Add a main tag of MaterialFrame.
Change the MaterialTheme property to AcrylicBlur.
Set macOSBehindWindowBlur to true.